### PR TITLE
Proposal: use integer IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ erDiagram
         integer user_id FK
     }
     PROJECTS {
-        string uuid PK "UNIQUE"
+        integer id PK
+        string uuid "UNIQUE"
         string name
         timestamp created_at
         timestamp updated_at
         integer user_id FK
     }
     DEPLOYMENTS {
-        string uuid PK "UNIQUE"
+        integer id PK
+        string uuid "UNIQUE"
         string name
         bson config "Stores config such as env vars"
         timestamp created_at


### PR DESCRIPTION
As integer IDs are:
- more easily processable by the database
- easier to keep track of across tables
- more lightweight

I suggest they be used as internal primary keys, with the public UUIDs losing their primary key status. This also strengthens security as internal database information is never leaked.